### PR TITLE
fix: supply a default alt text if it is missing

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -66,7 +66,7 @@ export const getStaticProps: GetStaticProps = async () => {
         ...(service.image?.image && {
           image: {
             image: service.image.image,
-            imageAlt: service.image.imageAlt,
+            imageAlt: service.image?.imageAlt || '',
           },
         }),
 


### PR DESCRIPTION
https://trello.com/c/Y77bYSpX/54-alpha-testing-issues

> Alt text is allowed to be missing in the CMS, but is expected when we generate the index page

It's not ideal that alt text _can_ be "". I'll find the entry and suggest text for it. It's difficult to do conditional requirement in the CMS (e.g. if there is an image file, there must be alt text, otherwise not) but I'll card this for next time.