### PR TITLE
fix: add link to open a Google Maps search for the location of a service

### DIFF
--- a/pages/service/[id].tsx
+++ b/pages/service/[id].tsx
@@ -12,6 +12,7 @@ import { Layout } from '../../src/Components/Layout'
 import { VisuallyHidden } from '../../src/Components/VisuallyHidden'
 import { MyBestLifeTheme } from '../../src/Theme'
 import { formatAgeDisplay } from '../../src/Components/Card'
+import { MapLink } from '../../src/Components/MapLink'
 
 interface ServicePageProps {
   serviceData: ServiceDetail
@@ -279,6 +280,7 @@ export const ServicePage = ({ serviceData }: ServicePageProps): JSX.Element => {
           <>
             <Heading as="h2">Where is it?</Heading>
             <p>{serviceData.location}</p>
+            <MapLink location={serviceData.location}></MapLink>
           </>
         ) : null}
         {serviceData.time ? (

--- a/public/assets/map_pin.svg
+++ b/public/assets/map_pin.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14.93 21.81"><defs><style>.cls-1{fill:#ffcd59;}</style></defs><g id="Layer_2" data-name="Layer 2"><g id="Layer_1-2" data-name="Layer 1"><path id="Path_44" data-name="Path 44" class="cls-1" d="M7.47,0a7.46,7.46,0,0,1,7.46,7.47h0c0,4.12-7.46,14.34-7.46,14.34S0,11.59,0,7.47A7.46,7.46,0,0,1,7.47,0Z"/></g></g></svg>

--- a/src/Components/MapLink.tsx
+++ b/src/Components/MapLink.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import styled from 'styled-components'
+
+interface MapLinkProps {
+  location: string
+}
+
+// Link with no text decoration and custom focus style
+const InvisibleLink = styled.a`
+  text-decoration: none;
+
+  &:focus {
+    outline: none;
+  }
+
+  &:focus > div {
+    outline: 2px dashed ${(props) => props.theme.colours.blue};
+    outline-offset: 2px;
+  }
+`
+
+const MapLinkContainer = styled.div`
+  display: flex;
+  color: ${(props) => props.theme.colours.purple};
+  font-weight: bold;
+  margin-bottom: 1rem;
+
+  div {
+    line-height: 1.8rem;
+  }
+`
+
+const MapPin = styled.div`
+  background-image: url('/assets/map_pin.svg');
+  background-size: contain;
+  background-repeat: no-repeat;
+  height: 1.8rem;
+  width: 2rem;
+`
+
+// Given a location, returns the link for a search for it on Google Maps
+const formMapLink = (location: string): string =>
+  `https://www.google.com/maps/search/${encodeURIComponent(location)}`
+
+const excludePattern = /(?:multiple locations)|(?:online)/gi
+
+export const MapLink = ({ location }: MapLinkProps): JSX.Element => {
+  if (excludePattern.test(location)) return <></>
+
+  return (
+    <InvisibleLink href={formMapLink(location)} target="_blank" rel="noopener">
+      <MapLinkContainer>
+        <MapPin />
+        <div>view on Google Maps</div>
+      </MapLinkContainer>
+    </InvisibleLink>
+  )
+}


### PR DESCRIPTION
Looks like this:

![Screenshot from 2021-03-15 12-40-54](https://user-images.githubusercontent.com/8274049/111154986-bd6e4180-858b-11eb-90d1-d49a35552001.png)

Resolves: https://trello.com/c/Ik1LfU8j/

The one problem I see with this approach is that it is liable to break if Google change the URL that you go to when you search for something on maps...

It also breaks when the location string is something like 'Multiple locations throughout Lambeth', since that isn't a place. Maybe add a hacky workaround that looks for strings like 'multiple locations', 'online', etc. and disables this link?