### PR TITLE
fix: fonts can unload on reload or rerender

### DIFF
--- a/src/Theme.ts
+++ b/src/Theme.ts
@@ -49,7 +49,7 @@ export const GlobalStyle = createGlobalStyle`
     src: url('/fonts/Lato-Regular.ttf') format('truetype');
     font-weight: 400;
     font-style: normal;
-    font-display: optional;
+    font-display: swap;
   }
 
   @font-face {
@@ -57,7 +57,7 @@ export const GlobalStyle = createGlobalStyle`
     src: url('/fonts/Catamaran-Bold.ttf') format('truetype');
     font-weight: 700;
     font-style: normal;
-    font-display: optional;
+    font-display: swap;
   }
 
   //


### PR DESCRIPTION
This seems to fix the problem.

https://trello.com/c/iF7n58EB/105-fonts-can-unload-on-page-changes-or-re-render-vv-e