### PR TITLE
fix: changing star rating makes Google Maps link pop in and out

### DIFF
--- a/src/Components/MapLink.tsx
+++ b/src/Components/MapLink.tsx
@@ -42,7 +42,7 @@ const MapPin = styled.div`
 const formMapLink = (location: string): string =>
   `https://www.google.com/maps/search/${encodeURIComponent(location)}`
 
-const excludePattern = /(?:multiple locations)|(?:online)/gi
+const excludePattern = /(?:multiple locations)|(?:online)/i
 
 export const MapLink = ({ location }: MapLinkProps): JSX.Element => {
   if (excludePattern.test(location)) return <></>


### PR DESCRIPTION
The world's smallest bugfix! Only one character changed :)

https://trello.com/c/L7oieuOL/112-changing-star-rating-makes-google-maps-link-disappear-and-appear