### PR TITLE
fix: test not showing anything before showWelcome set

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -36,6 +36,10 @@ export const ListPage: NextPage<ListPageProps> = ({ services }) => {
     stored === 'false' ? setShowWelcome(false) : setShowWelcome(true)
   }, [showWelcome])
 
+  if (showWelcome === null || showWelcome === undefined) {
+    return <></>
+  }
+
   return (
     <>
       {showWelcome ? (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -26,7 +26,7 @@ export type ServicePreview = Pick<
 
 export const ListPage: NextPage<ListPageProps> = ({ services }) => {
   // Default to showing the welcome screen
-  const [showWelcome, setShowWelcome] = useState<boolean>(true)
+  const [showWelcome, setShowWelcome] = useState<boolean | undefined>()
 
   useEffect(() => {
     // Attempt to retrieve the showWelcome value from local storage
@@ -36,7 +36,7 @@ export const ListPage: NextPage<ListPageProps> = ({ services }) => {
     stored === 'false' ? setShowWelcome(false) : setShowWelcome(true)
   }, [showWelcome])
 
-  if (showWelcome === null || showWelcome === undefined) {
+  if (showWelcome === undefined) {
     return <></>
   }
 


### PR DESCRIPTION
This is a test!

https://trello.com/c/trIzkMz0/113-upon-navigation-back-to-the-list-the-welcome-view-flashes-up-for-a-split-second-v-e