### PR TITLE
fix: filter can place you in an empty results page

### DIFF
--- a/src/Components/CardList.tsx
+++ b/src/Components/CardList.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react'
+import React, { useContext, useEffect, useState, useCallback } from 'react'
 import Link from 'next/link'
 import styled from 'styled-components'
 
@@ -147,6 +147,25 @@ export const CardList = ({
   const feelingWeight = 1
   const [page, setPage] = useState<number | null>(null)
 
+  const [
+    filteredServices,
+    setFilteredServices,
+  ] = useState<Array<ServicePreview> | null>(null)
+
+  // Derive some things we need to know from the filtered services
+  const totalPages = filteredServices
+    ? Math.ceil(filteredServices.length / ITEMS_PER_PAGE)
+    : 0
+  const isFirstPage = page === 0
+  const isLastPage = page === totalPages - 1
+  const toRender =
+    page !== null && filteredServices
+      ? filteredServices.slice(
+          page * ITEMS_PER_PAGE,
+          (page + 1) * ITEMS_PER_PAGE
+        )
+      : []
+
   // We use a reference to the last element in the card list so that we can
   // tell when the card list has rendered, and thus know when it is ok
   // to set the scroll position.
@@ -158,11 +177,49 @@ export const CardList = ({
     value: () => (page ? page.toString() : '0'),
   })
 
+  // Slightly hacky way of checking if we have changed the stuff that's in the card list
+  // by changing filter settings or other means.
+  const { recall: recallNumItems } = useRemember({
+    name: 'numItems',
+    value: () => (filteredServices ? filteredServices.length.toString() : '0'),
+  })
+
   useEffect(() => {
-    // Reset the page as remembered on initial render
-    setPage(parseInt(recallPage() || '0'))
+    if (filteredServices === null || totalPages === 0) {
+      return
+    }
+
+    // Recall pagination position, but make sure the number of items
+    // hasn't changed since we were last here, and if it has, reset to
+    // the start of the list.
+    if (parseInt(recallNumItems() || '0') !== filteredServices.length) {
+      setPage(0)
+      resetPosition()
+    } else {
+      setPage(parseInt(recallPage() || '0'))
+    }
+
+    // We only want to run this once, once the filtered services list has been loaded
     // eslint-disable-next-line
-  }, [])
+  }, [filteredServices === null])
+
+  useEffect(() => {
+    // If the number of filtered services has changed without navigation, i.e. because
+    // the save button on a card has been clicked in the saved list mode, check we're not
+    // in an invalid pagination position.
+    if (!filteredServices || filteredServices.length === 0 || page === null) {
+      return
+    }
+
+    if (page >= totalPages) {
+      setPage(totalPages - 1)
+      resetPosition()
+    }
+
+    // Run this every time the number of pages changes, since that is what will
+    // cause problems (e.g. being stuck on a non-existent page)
+    // eslint-disable-next-line
+  }, [totalPages])
 
   useEffect(() => {
     if (loadedRef === null) return
@@ -179,154 +236,165 @@ export const CardList = ({
     })
   }
 
-  function ageFilter(item: ServicePreview, ageInput: string | undefined) {
-    let ageNumber: number
+  const ageFilter = useCallback(
+    (item: ServicePreview, ageInput: string | undefined) => {
+      let ageNumber: number
 
-    switch (ageInput) {
-      case '<15':
-        ageNumber = 14
-        break
-      case '15':
-        ageNumber = 15
-        break
-      case '16':
-        ageNumber = 16
-        break
-      case '17':
-        ageNumber = 17
-        break
-      case '18':
-        ageNumber = 18
-        break
-      case '18+':
-        ageNumber = 19
-        break
-      default:
-        ageNumber = -1
-    }
-
-    // No age has been set, return all entries
-    if (ageNumber === -1) return true
-
-    // There is an age band
-    if (item.age?.minAge && item.age?.maxAge) {
-      if (item.age.minAge <= ageNumber && ageNumber <= item.age.maxAge) {
-        return true
+      switch (ageInput) {
+        case '<15':
+          ageNumber = 14
+          break
+        case '15':
+          ageNumber = 15
+          break
+        case '16':
+          ageNumber = 16
+          break
+        case '17':
+          ageNumber = 17
+          break
+        case '18':
+          ageNumber = 18
+          break
+        case '18+':
+          ageNumber = 19
+          break
+        default:
+          ageNumber = -1
       }
-      return false
-    }
 
-    // There is only a minimum age
-    if (item.age?.minAge && item.age.minAge <= ageNumber) {
-      return true
-    }
+      // No age has been set, return all entries
+      if (ageNumber === -1) return true
 
-    // There is only a maximum age
-    if (item.age?.maxAge && item.age.maxAge >= ageNumber) {
-      return true
-    }
-  }
-
-  function formatFilter(item: ServicePreview) {
-    if (formats.length === 0) {
-      return true
-    }
-
-    if (item?.format && formats.includes(item?.format)) return true
-  }
-
-  function genderFilter(
-    item: ServicePreview,
-    genderInput: Array<string> | undefined
-  ) {
-    // If no preference is set for user or service, return everything
-    if (genderInput?.length === 0 || item?.gender?.length === 0) {
-      return true
-    }
-
-    genderInput?.filter((gen) => {
-      const gender = gen as Gender
-      if (!item?.gender?.includes(gender)) {
+      // There is an age band
+      if (item.age?.minAge && item.age?.maxAge) {
+        if (item.age.minAge <= ageNumber && ageNumber <= item.age.maxAge) {
+          return true
+        }
         return false
-      } else {
+      }
+
+      // There is only a minimum age
+      if (item.age?.minAge && item.age.minAge <= ageNumber) {
         return true
       }
-    })
-  }
 
-  function assignQuizScore(item: ServicePreview) {
-    item.score = 0
+      // There is only a maximum age
+      if (item.age?.maxAge && item.age.maxAge >= ageNumber) {
+        return true
+      }
+    },
+    []
+  )
 
-    // Make sure we won't have any casing inconsistency for matching categories
-    const quizCategories = quizAnswers?.whatsOnMind.map((item) => {
-      return item.toLowerCase()
-    })
+  const formatFilter = useCallback(
+    (item: ServicePreview) => {
+      if (formats.length === 0) {
+        return true
+      }
 
-    // Category matching
-    if (
-      item.categories?.category1 &&
-      quizCategories?.includes(item.categories?.category1.toLowerCase())
-    ) {
-      item.score += categoryWeight
-    }
+      if (item?.format && formats.includes(item?.format)) return true
+    },
+    [formats]
+  )
 
-    if (
-      item.categories?.category2 &&
-      quizCategories?.includes(item.categories?.category2.toLowerCase())
-    ) {
-      item.score += categoryWeight
-    }
+  const genderFilter = useCallback(
+    (item: ServicePreview, genderInput: Array<string> | undefined) => {
+      // If no preference is set for user or service, return everything
+      if (genderInput?.length === 0 || item?.gender?.length === 0) {
+        return true
+      }
 
-    const interestMatches = quizAnswers?.interests?.filter((value) => {
-      const interest = value as Interest
-      if (item?.interests.includes(interest)) return true
-    })
-
-    item.score += (interestMatches?.length || 0) * interestWeight
-
-    // Feeling matching
-    const feelingMatches = quizAnswers?.howAreFeeling?.filter((value) => {
-      if (item?.feelings.includes(value)) return true
-    })
-
-    item.score += (feelingMatches?.length || 0) * feelingWeight
-
-    // filter this list by only services that receive a score and are eligible
-    if (item.score > 0) {
-      return true
-    }
-  }
-
-  let filteredServices: Array<ServicePreview>
-
-  if (listType === 'saved') {
-    filteredServices = services.filter((item) => saved.includes(item.id))
-  } else if (listType === 'quiz') {
-    filteredServices = services
-      .filter(assignQuizScore)
-      .filter((item) => ageFilter(item, quizAnswers?.age))
-      .filter((item) => genderFilter(item, quizAnswers?.gender))
-      .sort((a, b) => {
-        return b.score - a.score
+      genderInput?.filter((gen) => {
+        const gender = gen as Gender
+        if (!item?.gender?.includes(gender)) {
+          return false
+        } else {
+          return true
+        }
       })
-  } else {
-    filteredServices = services
-      .filter((item) => ageFilter(item, age))
-      .filter(formatFilter)
-  }
+    },
+    []
+  )
 
-  const totalPages = Math.ceil(filteredServices.length / ITEMS_PER_PAGE)
-  const isFirstPage = page === 0
-  const isLastPage = page === totalPages - 1
-  const toRender =
-    page !== null
-      ? filteredServices.slice(
-          page * ITEMS_PER_PAGE,
-          (page + 1) * ITEMS_PER_PAGE
-        )
-      : []
+  const assignQuizScore = useCallback(
+    (item: ServicePreview) => {
+      item.score = 0
 
-  return page !== null ? (
+      // Make sure we won't have any casing inconsistency for matching categories
+      const quizCategories = quizAnswers?.whatsOnMind.map((item) => {
+        return item.toLowerCase()
+      })
+
+      // Category matching
+      if (
+        item.categories?.category1 &&
+        quizCategories?.includes(item.categories?.category1.toLowerCase())
+      ) {
+        item.score += categoryWeight
+      }
+
+      if (
+        item.categories?.category2 &&
+        quizCategories?.includes(item.categories?.category2.toLowerCase())
+      ) {
+        item.score += categoryWeight
+      }
+
+      const interestMatches = quizAnswers?.interests?.filter((value) => {
+        const interest = value as Interest
+        if (item?.interests.includes(interest)) return true
+      })
+
+      item.score += (interestMatches?.length || 0) * interestWeight
+
+      // Feeling matching
+      const feelingMatches = quizAnswers?.howAreFeeling?.filter((value) => {
+        if (item?.feelings.includes(value)) return true
+      })
+
+      item.score += (feelingMatches?.length || 0) * feelingWeight
+
+      // filter this list by only services that receive a score and are eligible
+      if (item.score > 0) {
+        return true
+      }
+    },
+    [quizAnswers]
+  )
+
+  useEffect(() => {
+    let filtered: Array<ServicePreview>
+
+    if (listType === 'saved') {
+      filtered = services.filter((item) => saved.includes(item.id))
+    } else if (listType === 'quiz') {
+      filtered = services
+        .filter(assignQuizScore)
+        .filter((item) => ageFilter(item, quizAnswers?.age))
+        .filter((item) => genderFilter(item, quizAnswers?.gender))
+        .sort((a, b) => {
+          return b.score - a.score
+        })
+    } else {
+      filtered = services
+        .filter((item) => ageFilter(item, age))
+        .filter(formatFilter)
+    }
+
+    setFilteredServices(filtered)
+  }, [
+    quizAnswers,
+    saved,
+    services,
+    listType,
+    ageFilter,
+    genderFilter,
+    formatFilter,
+    assignQuizScore,
+  ])
+
+  return page !== null && filteredServices !== null ? (
     <>
       {filteredServices && filteredServices.length > 0 ? (
         <>

--- a/src/context/QuizContext.tsx
+++ b/src/context/QuizContext.tsx
@@ -179,6 +179,19 @@ export const QuizProvider = ({ children }: QuizProviderProps): JSX.Element => {
     []
   )
 
+  // Have to memoize this to prevent infinite useEffect loops with anything
+  // that uses this result as a dependency.
+  const fullData = useMemo(
+    (): FullData => ({
+      howAreFeeling,
+      whatsOnMind,
+      interests,
+      gender,
+      age,
+    }),
+    [howAreFeeling, whatsOnMind, interests, gender, age]
+  )
+
   const value: IQuizContext = useMemo(
     () => ({
       howAreFeelingGet: (key) => getCategoryValue(howAreFeeling, key),
@@ -191,13 +204,7 @@ export const QuizProvider = ({ children }: QuizProviderProps): JSX.Element => {
       genderToggle: (key) => toggleCategoryValue(setGender, key),
       ageGet: () => age,
       ageSet: setAge,
-      fullDataGet: () => ({
-        howAreFeeling,
-        whatsOnMind,
-        interests,
-        gender,
-        age,
-      }),
+      fullDataGet: () => fullData,
       clearProgress,
       quizComplete,
       setQuizComplete,


### PR DESCRIPTION
https://trello.com/c/QA2kRu0M/130-filter-can-place-you-in-an-empty-results-page

This PR does a few things, which were all sort of necessary to make this surprisingly tricky fix:

- doesn't filter stuff on every render (instead only when things change), which should help speed up things (not that there was a noticeable slowdown anyway)
- adds extra checks in for changes to the card list inbetween page loads and otherwise
- resets the pagination state when necessary
