### PR TITLE
fix: name checkbox element

### DIFF
--- a/src/Components/Checkbox.tsx
+++ b/src/Components/Checkbox.tsx
@@ -59,6 +59,7 @@ const CheckboxItem = styled.li`
 
 export const Checkbox = ({
   label,
+  checked,
   onChange,
   singleCheckbox,
 }: CheckboxProps): JSX.Element => {
@@ -66,7 +67,7 @@ export const Checkbox = ({
     <CheckboxItem as={singleCheckbox ? 'div' : 'li'}>
       <label>
         {label}
-        <input type="checkbox" onChange={onChange}></input>
+        <input type="checkbox" checked={checked} onChange={onChange}></input>
         <CheckboxBackground>
           <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/src/Components/Checkbox.tsx
+++ b/src/Components/Checkbox.tsx
@@ -7,7 +7,18 @@ interface CheckboxProps {
   singleCheckbox?: boolean
 }
 
-const CheckboxItem = styled.li<{ checked: boolean }>`
+const CheckboxBackground = styled.div`
+  align-self: flex-start;
+  background: ${(props) => props.theme.colours.white};
+  border: 2px solid ${(props) => props.theme.colours.purple};
+  cursor: pointer;
+  flex-shrink: 0;
+  height: 44px;
+  margin-left: 0.5rem;
+  width: 44px;
+`
+
+const CheckboxItem = styled.li`
   list-style: none;
   margin-bottom: 1rem;
   min-height: 44px;
@@ -30,23 +41,15 @@ const CheckboxItem = styled.li<{ checked: boolean }>`
     white-space: nowrap; /* added line */
     border: 0;
 
-    &:focus ~ span {
+    &:focus ~ ${CheckboxBackground} {
       outline: 2px dashed ${(props) => props.theme.colours.blue};
       outline-offset: 4px;
     }
-  }
 
-  span {
-    align-self: flex-start;
-    flex-shrink: 0;
-    height: 44px;
-    width: 44px;
-    border: 2px solid ${(props) => props.theme.colours.purple};
-
-    ${(props) =>
-      props.checked
-        ? `background: ${props.theme.colours.purple}`
-        : `background: ${props.theme.colours.white}`}
+    &:checked ~ ${CheckboxBackground} {
+      background: ${(props) => props.theme.colours.purple};
+      transition: 0.3s;
+    }
   }
 
   svg {
@@ -56,16 +59,15 @@ const CheckboxItem = styled.li<{ checked: boolean }>`
 
 export const Checkbox = ({
   label,
-  checked,
   onChange,
   singleCheckbox,
 }: CheckboxProps): JSX.Element => {
   return (
-    <CheckboxItem as={singleCheckbox ? 'div' : 'li'} checked={checked}>
+    <CheckboxItem as={singleCheckbox ? 'div' : 'li'}>
       <label>
         {label}
-        <input type="checkbox" checked={checked} onChange={onChange}></input>
-        <span>
+        <input type="checkbox" onChange={onChange}></input>
+        <CheckboxBackground>
           <svg
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
@@ -79,7 +81,7 @@ export const Checkbox = ({
               d="M5 13l4 4L19 7"
             />
           </svg>
-        </span>
+        </CheckboxBackground>
       </label>
     </CheckboxItem>
   )


### PR DESCRIPTION
https://trello.com/c/1zpczv6c/198-checkbox-element-child-styling

- Naming the background element prevents styling being applied to any child elements