### PR TITLE
feat: add cors header for api routes

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,4 +8,15 @@ module.exports = withPWA({
   pwa: {
     dest: 'public',
   },
+  async headers() {
+    return [
+      {
+        // match all API routes
+        source: '/api/:path*',
+        headers: [
+          { key: 'Access-Control-Allow-Origin', value: '*' },
+        ],
+      },
+    ]
+  }
 })


### PR DESCRIPTION
> Hello Matt
> 
> Would you mind adding the following header on all HTTP responses?
> 
> Access-Control-Allow-Origin: *
> This will mean that your API can be accessed by tools that run from web pages such as the API Query Tool.
> 
> We've not been very explicit about that so far but have now published our implementation notes as the page Open Referral UK > API Implementation.
> 
> Thanks very much
> Mike